### PR TITLE
Only keep non-empty remnants around

### DIFF
--- a/eachline.js
+++ b/eachline.js
@@ -147,6 +147,9 @@ Transformer.prototype._transform = function(chunk, encoding, done) {
 			else {
 				xform.remnant = chunk.slice(start);
 			}
+			if(!xform.remnant.length) {
+				delete xform.remnant;
+			}
 
 			return done();
 		}


### PR DESCRIPTION
This prevents us from sending an unnecessary empty line through in
_flush.

To see the effects, use a simple script like in https://github.com/williamwicks/node-eachline/issues/2

```js
var fs = require("fs");
var eachline = require("eachline");

fs.createReadStream('./data.txt')
    .pipe(eachline(function(line, i){
        console.log(i, line);
    }));
```

and run it on a small file.  Without this PR, there's an extraneous blank line at the end of every file.